### PR TITLE
When running 'make doc' - make does not do anything, because director…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	$(MAKE) -C tests clean
 	$(MAKE) -C go clean
 
-doc:
+docs:
 	$(MAKE) -C doc
 	
 pkg: all


### PR DESCRIPTION
…y/target already exists.